### PR TITLE
Remove Trap from Example Database

### DIFF
--- a/Example/ExampleDatabase/Example_Database.asset
+++ b/Example/ExampleDatabase/Example_Database.asset
@@ -61,10 +61,3 @@ MonoBehaviour:
       _classRef: Lockstep.Stop, Assembly-CSharp
     _listenInputCode: 
     _informationGather: 0
-  - _name: Trap
-    _description: 
-    _icon: {fileID: 0}
-    _script:
-      _classRef: InvasionDay.Trap, Assembly-CSharp
-    _listenInputCode: 
-    _informationGather: 0


### PR DESCRIPTION
A trap from the InvasionDay namespace was added to the example project
database I assume erroneously. This commit removes it. There was a warning being generated by it.
