### PR TITLE
Change Vector2d GetStateHash to GetHashCode

### DIFF
--- a/Core/Game/Agents/AgentController.cs
+++ b/Core/Game/Agents/AgentController.cs
@@ -216,7 +216,7 @@ namespace Lockstep
                 if (GlobalAgentActive [i])
                 {
                     LSAgent agent = GlobalAgents [i];
-                    int n1 = agent.Body._position.GetStateHash() + agent.Body._rotation.GetStateHash();
+                    int n1 = agent.Body._position.GetHashCode() + agent.Body._rotation.GetHashCode();
                     switch (operationToggle)
                     {
                         case 0:
@@ -236,8 +236,8 @@ namespace Lockstep
                     }
                     if (agent.Body.IsNotNull())
                     {
-                        hash ^= agent.Body._position.GetStateHash();
-                        hash ^= agent.Body._position.GetStateHash();
+                        hash ^= agent.Body._position.GetHashCode();
+                        hash ^= agent.Body._position.GetHashCode();
                     }
                 }
             }

--- a/Core/Game/Agents/LSAgent.cs
+++ b/Core/Game/Agents/LSAgent.cs
@@ -423,9 +423,9 @@ namespace Lockstep {
             long hash = 3;
             hash ^= this.GlobalID;
             hash ^= this.LocalID;
-            hash ^= this.Body._position.GetStateHash ();
-            hash ^= this.Body._rotation.GetStateHash ();
-            hash ^= this.Body.Velocity.GetStateHash ();
+            hash ^= this.Body._position.GetHashCode ();
+            hash ^= this.Body._rotation.GetHashCode ();
+            hash ^= this.Body.Velocity.GetHashCode ();
             return hash;
         }
             

--- a/Core/Simulation/Math/Vector2d.cs
+++ b/Core/Simulation/Math/Vector2d.cs
@@ -452,7 +452,7 @@ namespace Lockstep
             return x * 31 + y * 7;
         }
 
-        public int GetStateHash()
+        public override int GetHashCode()
         {
             return (int)(GetLongHashCode() % int.MaxValue);
         }


### PR DESCRIPTION
Vector2d’s GetStateHash function should be overriding object
GetHashCode. This change fixes the issue and all references to
Vector2d’s GetStateHash.
