### PR TITLE
Update Diplomacy fix

### DIFF
--- a/Core/Game/Agents/AgentControllerSystem/AgentController.cs
+++ b/Core/Game/Agents/AgentControllerSystem/AgentController.cs
@@ -337,8 +337,8 @@ namespace Lockstep
 			for (int i = 0; i < InstanceManagers.Count; i++)
 			{
 				var other = InstanceManagers[i];
-				other.SetAllegiance(newCont, other.DefaultAllegiance);
-				newCont.SetAllegiance(other, newCont.DefaultAllegiance);
+				other.SetAllegiance(newCont, newCont.DefaultAllegiance);
+				newCont.SetAllegiance(other, other.DefaultAllegiance);
 			}
 		}
 


### PR DESCRIPTION
The allegiance was set with the wrong value - probably because of a "typo"